### PR TITLE
Add localization support and user preferences

### DIFF
--- a/wp-content/themes/dottorbot-theme/functions.php
+++ b/wp-content/themes/dottorbot-theme/functions.php
@@ -1,6 +1,11 @@
 <?php
 require_once get_template_directory() . '/api.php';
 
+function dottorbot_theme_setup() {
+    load_theme_textdomain('dottorbot', get_template_directory() . '/languages');
+}
+add_action('after_setup_theme', 'dottorbot_theme_setup');
+
 function dottorbot_enqueue_assets() {
     $theme_dir = get_template_directory_uri();
     $style_path = get_template_directory() . '/dist/style.css';

--- a/wp-content/themes/dottorbot-theme/style.css
+++ b/wp-content/themes/dottorbot-theme/style.css
@@ -3,6 +3,7 @@ Theme Name: DottorBot Theme
 Author: DottorBot Team
 Description: Custom theme for DottorBot chatbot prototype.
 Version: 0.1.0
+Text Domain: dottorbot
 */
 
 @tailwind base;


### PR DESCRIPTION
## Summary
- Load `dottorbot` text domain for plugin and theme
- Add user profile settings for tone and detail level stored in user meta

## Testing
- `php -l wp-content/plugins/dottorbot/dottorbot.php`
- `php -l wp-content/themes/dottorbot-theme/functions.php`


------
https://chatgpt.com/codex/tasks/task_e_689b3c67cf4c8333bf66d2f8d946485b