### PR TITLE
feat(pwa): improve offline diary caching

### DIFF
--- a/wp-content/themes/dottorbot-theme/manifest.json
+++ b/wp-content/themes/dottorbot-theme/manifest.json
@@ -1,7 +1,9 @@
 {
   "name": "DottorBot",
   "short_name": "DottorBot",
+  "lang": "it",
   "start_url": "/",
+  "scope": "/",
   "display": "standalone",
   "background_color": "#ffffff",
   "theme_color": "#0ea5e9",


### PR DESCRIPTION
## Summary
- add language and scope metadata in PWA manifest
- cache diary endpoint and page for offline access via service worker

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689b749b37448333862a78421202a6bd