### PR TITLE
Fix Gutenberg chat block render callback

### DIFF
--- a/wp-content/themes/dottorbot-theme/functions.php
+++ b/wp-content/themes/dottorbot-theme/functions.php
@@ -71,7 +71,7 @@ function dottorbot_register_block() {
     );
     register_block_type('dottorbot/chat', array(
         'editor_script' => 'dottorbot-block-editor',
-        'render_callback' => 'dottorbot_render_shortcode',
+        'render_callback' => 'dottorbot_render_chat_shortcode',
     ));
 }
 add_action('init', 'dottorbot_register_block');


### PR DESCRIPTION
## Summary
- Link Gutenberg chat block to the correct render callback

## Testing
- `php -l wp-content/themes/dottorbot-theme/functions.php`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689b88831ff483339dafabef1283d34e