### PR TITLE
Secure REST endpoints with nonce verification

### DIFF
--- a/wp-content/plugins/dottorbot/dottorbot.php
+++ b/wp-content/plugins/dottorbot/dottorbot.php
@@ -207,12 +207,26 @@ function dottorbot_diary_decrypt(string $data): ?array {
     return $json ? json_decode($json, true) : null;
 }
 
+/**
+ * Basic permission check for DottorBot REST endpoints.
+ */
+function dottorbot_rest_permission_check(WP_REST_Request $request): bool {
+    if (!is_user_logged_in()) {
+        return false;
+    }
+    $nonce = $request->get_header('X-WP-Nonce');
+    if (!$nonce || !wp_verify_nonce($nonce, 'wp_rest')) {
+        return false;
+    }
+    return current_user_can('read');
+}
+
 // Register REST API routes.
 add_action('rest_api_init', function () {
     register_rest_route('dottorbot/v1', '/chat', [
         'methods'  => 'POST',
         'callback' => 'dottorbot_rest_chat',
-        'permission_callback' => '__return_true',
+        'permission_callback' => 'dottorbot_rest_permission_check',
     ]);
 
     register_rest_route('dottorbot/v1', '/stripe/checkout', [
@@ -226,31 +240,31 @@ add_action('rest_api_init', function () {
     register_rest_route('dottorbot/v1', '/event', [
         'methods'  => 'POST',
         'callback' => 'dottorbot_rest_event',
-        'permission_callback' => '__return_true',
+        'permission_callback' => 'dottorbot_rest_permission_check',
     ]);
 
     register_rest_route('dottorbot/v1', '/diary', [
         'methods'  => WP_REST_Server::READABLE,
         'callback' => 'dottorbot_diary_list',
-        'permission_callback' => '__return_true',
+        'permission_callback' => 'dottorbot_rest_permission_check',
     ]);
 
     register_rest_route('dottorbot/v1', '/diary', [
         'methods'  => WP_REST_Server::CREATABLE,
         'callback' => 'dottorbot_diary_create',
-        'permission_callback' => '__return_true',
+        'permission_callback' => 'dottorbot_rest_permission_check',
     ]);
 
     register_rest_route('dottorbot/v1', '/diary/(?P<id>\d+)', [
         'methods'  => WP_REST_Server::EDITABLE,
         'callback' => 'dottorbot_diary_update',
-        'permission_callback' => '__return_true',
+        'permission_callback' => 'dottorbot_rest_permission_check',
     ]);
 
     register_rest_route('dottorbot/v1', '/diary/(?P<id>\d+)', [
         'methods'  => WP_REST_Server::DELETABLE,
         'callback' => 'dottorbot_diary_delete',
-        'permission_callback' => '__return_true',
+        'permission_callback' => 'dottorbot_rest_permission_check',
     ]);
 
     register_rest_route('dottorbot/v1', '/export', [
@@ -272,7 +286,7 @@ add_action('rest_api_init', function () {
     register_rest_route('dottorbot/v1', '/consent', [
         'methods'  => 'POST',
         'callback' => 'dottorbot_rest_consent',
-        'permission_callback' => '__return_true',
+        'permission_callback' => 'dottorbot_rest_permission_check',
     ]);
 });
 

--- a/wp-content/themes/dottorbot-theme/dist/chat.js
+++ b/wp-content/themes/dottorbot-theme/dist/chat.js
@@ -53,7 +53,8 @@ document.addEventListener('DOMContentLoaded', () => {
     try {
       const res = await fetch('/wp-json/dottorbot/v1/chat', {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
+        credentials: 'same-origin',
+        headers: { 'Content-Type': 'application/json', 'X-WP-Nonce': dottorbotChat.nonce },
         body: JSON.stringify({ message: text })
       });
       const data = await res.json();
@@ -107,7 +108,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
     document.getElementById('db-upgrade').addEventListener('click', async () => {
       try {
-        const res = await fetch(url, { method: 'POST' });
+        const res = await fetch(url, { method: 'POST', credentials: 'same-origin', headers: { 'X-WP-Nonce': dottorbotChat.nonce } });
         const data = await res.json();
         if (data.url) {
           window.location.href = data.url;

--- a/wp-content/themes/dottorbot-theme/dist/diary.js
+++ b/wp-content/themes/dottorbot-theme/dist/diary.js
@@ -17,7 +17,7 @@ document.addEventListener('DOMContentLoaded', function () {
   btnContainer.appendChild(btnPdf);
   root.appendChild(btnContainer);
 
-  fetch('/wp-json/dottorbot/v1/diary')
+  fetch('/wp-json/dottorbot/v1/diary', { credentials: 'same-origin', headers: { 'X-WP-Nonce': dottorbotDiary.nonce } })
     .then(r => r.json())
     .then(entries => {
       if (!Array.isArray(entries)) return;

--- a/wp-content/themes/dottorbot-theme/dist/privacy.js
+++ b/wp-content/themes/dottorbot-theme/dist/privacy.js
@@ -42,7 +42,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
     async function exportData(format) {
       try {
-        const res = await fetch('/wp-json/dottorbot/v1/export?format=' + format, { credentials: 'include' });
+        const res = await fetch('/wp-json/dottorbot/v1/export?format=' + format, { credentials: 'same-origin', headers: { 'X-WP-Nonce': dottorbotPrivacy.nonce } });
         const text = await res.text();
         const blob = new Blob([text], { type: format === 'csv' ? 'text/csv' : 'application/json' });
         const url = URL.createObjectURL(blob);
@@ -63,7 +63,7 @@ document.addEventListener('DOMContentLoaded', () => {
     document.getElementById('db-purge').addEventListener('click', async () => {
       if (!confirm('Eliminare tutti i dati?')) return;
       try {
-        await fetch('/wp-json/dottorbot/v1/purge', { method: 'DELETE', credentials: 'include' });
+        await fetch('/wp-json/dottorbot/v1/purge', { method: 'DELETE', credentials: 'same-origin', headers: { 'X-WP-Nonce': dottorbotPrivacy.nonce } });
       } catch (e) {
         // ignore errors
       } finally {

--- a/wp-content/themes/dottorbot-theme/functions.php
+++ b/wp-content/themes/dottorbot-theme/functions.php
@@ -20,11 +20,17 @@ function dottorbot_enqueue_assets() {
     $chat_path = get_template_directory() . '/dist/chat.js';
     if (file_exists($chat_path)) {
         wp_enqueue_script('dottorbot-chat', $theme_dir . '/dist/chat.js', array(), filemtime($chat_path), true);
+        wp_localize_script('dottorbot-chat', 'dottorbotChat', array(
+            'nonce' => wp_create_nonce('wp_rest'),
+        ));
     }
 
     $privacy_path = get_template_directory() . '/dist/privacy.js';
     if (file_exists($privacy_path)) {
         wp_enqueue_script('dottorbot-privacy', $theme_dir . '/dist/privacy.js', array(), filemtime($privacy_path), true);
+        wp_localize_script('dottorbot-privacy', 'dottorbotPrivacy', array(
+            'nonce' => wp_create_nonce('wp_rest'),
+        ));
     }
 
     $diary_path = get_template_directory() . '/dist/diary.js';
@@ -32,6 +38,9 @@ function dottorbot_enqueue_assets() {
         wp_enqueue_script('chartjs', 'https://cdn.jsdelivr.net/npm/chart.js', array(), null, true);
         wp_enqueue_script('jspdf', 'https://cdn.jsdelivr.net/npm/jspdf@2.5.1/dist/jspdf.umd.min.js', array(), null, true);
         wp_enqueue_script('dottorbot-diary', $theme_dir . '/dist/diary.js', array('chartjs', 'jspdf'), filemtime($diary_path), true);
+        wp_localize_script('dottorbot-diary', 'dottorbotDiary', array(
+            'nonce' => wp_create_nonce('wp_rest'),
+        ));
     }
 
     $pwa_path = get_template_directory() . '/dist/pwa.js';

--- a/wp-content/themes/dottorbot-theme/js/chat.js
+++ b/wp-content/themes/dottorbot-theme/js/chat.js
@@ -53,7 +53,11 @@ document.addEventListener('DOMContentLoaded', () => {
     try {
       const res = await fetch('/wp-json/dottorbot/v1/chat', {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
+        credentials: 'same-origin',
+        headers: {
+          'Content-Type': 'application/json',
+          'X-WP-Nonce': dottorbotChat.nonce
+        },
         body: JSON.stringify({ message: text })
       });
       const data = await res.json();
@@ -107,7 +111,11 @@ document.addEventListener('DOMContentLoaded', () => {
 
     document.getElementById('db-upgrade').addEventListener('click', async () => {
       try {
-        const res = await fetch(url, { method: 'POST' });
+        const res = await fetch(url, {
+          method: 'POST',
+          credentials: 'same-origin',
+          headers: { 'X-WP-Nonce': dottorbotChat.nonce }
+        });
         const data = await res.json();
         if (data.url) {
           window.location.href = data.url;

--- a/wp-content/themes/dottorbot-theme/js/diary.js
+++ b/wp-content/themes/dottorbot-theme/js/diary.js
@@ -17,7 +17,10 @@ document.addEventListener('DOMContentLoaded', function () {
   btnContainer.appendChild(btnPdf);
   root.appendChild(btnContainer);
 
-  fetch('/wp-json/dottorbot/v1/diary')
+  fetch('/wp-json/dottorbot/v1/diary', {
+    credentials: 'same-origin',
+    headers: { 'X-WP-Nonce': dottorbotDiary.nonce }
+  })
     .then(r => r.json())
     .then(entries => {
       if (!Array.isArray(entries)) return;

--- a/wp-content/themes/dottorbot-theme/js/privacy.js
+++ b/wp-content/themes/dottorbot-theme/js/privacy.js
@@ -42,7 +42,10 @@ document.addEventListener('DOMContentLoaded', () => {
 
     async function exportData(format) {
       try {
-        const res = await fetch('/wp-json/dottorbot/v1/export?format=' + format, { credentials: 'include' });
+        const res = await fetch('/wp-json/dottorbot/v1/export?format=' + format, {
+          credentials: 'same-origin',
+          headers: { 'X-WP-Nonce': dottorbotPrivacy.nonce }
+        });
         const text = await res.text();
         const blob = new Blob([text], { type: format === 'csv' ? 'text/csv' : 'application/json' });
         const url = URL.createObjectURL(blob);
@@ -63,7 +66,11 @@ document.addEventListener('DOMContentLoaded', () => {
     document.getElementById('db-purge').addEventListener('click', async () => {
       if (!confirm('Eliminare tutti i dati?')) return;
       try {
-        await fetch('/wp-json/dottorbot/v1/purge', { method: 'DELETE', credentials: 'include' });
+        await fetch('/wp-json/dottorbot/v1/purge', {
+          method: 'DELETE',
+          credentials: 'same-origin',
+          headers: { 'X-WP-Nonce': dottorbotPrivacy.nonce }
+        });
       } catch (e) {
         // ignore errors
       } finally {


### PR DESCRIPTION
## Summary
- Guard REST API endpoints with logged-in and nonce checks
- Expose REST nonce to front-end scripts and send it with requests

## Testing
- `npm test`
- `php -l wp-content/plugins/dottorbot/dottorbot.php`
- `php -l wp-content/themes/dottorbot-theme/functions.php`


------
https://chatgpt.com/codex/tasks/task_e_689b8edb1a108333a8502d39af12a8dc