### PR TITLE
Add front-page template with DottorBot shortcodes

### DIFF
--- a/wp-content/themes/dottorbot-theme/front-page.php
+++ b/wp-content/themes/dottorbot-theme/front-page.php
@@ -1,0 +1,23 @@
+<?php
+?><!DOCTYPE html>
+<html <?php language_attributes(); ?>>
+<head>
+    <meta charset="<?php bloginfo('charset'); ?>" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <?php wp_head(); ?>
+</head>
+<body <?php body_class(); ?>>
+    <main class="prose mx-auto p-4">
+        <?php
+        echo do_shortcode('[dottorbot]');
+        if (shortcode_exists('dottorbot_diary')) {
+            echo do_shortcode('[dottorbot_diary]');
+        }
+        if (shortcode_exists('dottorbot_privacy')) {
+            echo do_shortcode('[dottorbot_privacy]');
+        }
+        ?>
+    </main>
+    <?php wp_footer(); ?>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Add WordPress `front-page.php` template to render DottorBot chat and optional diary/privacy shortcodes.

## Testing
- `npm test`
- `cd wp-content/themes/dottorbot-theme && npm test`
- `php -l wp-content/themes/dottorbot-theme/front-page.php`


------
https://chatgpt.com/codex/tasks/task_e_689b9e0e4b4483339cf526a3c0fd3817