### PR TITLE
Add WordPress page template for home-bot shortcode

### DIFF
--- a/wp-content/themes/dottorbot-theme/page-home-bot.php
+++ b/wp-content/themes/dottorbot-theme/page-home-bot.php
@@ -1,0 +1,15 @@
+<?php
+?><!DOCTYPE html>
+<html <?php language_attributes(); ?>>
+<head>
+    <meta charset="<?php bloginfo('charset'); ?>" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <?php wp_head(); ?>
+</head>
+<body <?php body_class(); ?>>
+    <main class="prose mx-auto p-4">
+        <?php echo do_shortcode('[dottorbot]'); ?>
+    </main>
+    <?php wp_footer(); ?>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Add `page-home-bot.php` template rendering the `[dottorbot]` shortcode for the "home-bot" page.

## Testing
- `composer install --no-dev`
- `npm install`
- `npm run build` *(fails: Specified input file src/input.css does not exist)*
- `npm install` (wp-content/themes/dottorbot-theme)
- `npm run build` (wp-content/themes/dottorbot-theme)
- `npm test`
- `php -l wp-content/themes/dottorbot-theme/page-home-bot.php`


------
https://chatgpt.com/codex/tasks/task_e_689bbde57c0883339d6e0669b32b6f37