### PR TITLE
Move shortcodes from theme to plugin

### DIFF
--- a/wp-content/plugins/dottorbot/dottorbot.php
+++ b/wp-content/plugins/dottorbot/dottorbot.php
@@ -817,6 +817,26 @@ function dottorbot_render_badge_notification(): void {
     }
 }
 
+function dottorbot_render_chat_shortcode() {
+    wp_enqueue_script('dottorbot-chat');
+    return '<div id="dottorbot-chat"></div>';
+}
+
+function dottorbot_render_diary_shortcode() {
+    wp_enqueue_script('dottorbot-diary');
+    wp_enqueue_script('chartjs');
+    wp_enqueue_script('jspdf');
+    return '<div id="dottorbot-diary"></div>';
+}
+
+function dottorbot_render_privacy_shortcode() {
+    wp_enqueue_script('dottorbot-privacy');
+    return '<button id="dottorbot-privacy-open">' . esc_html__('Privacy', 'dottorbot') . '</button>';
+}
+
+add_shortcode('dottorbot', 'dottorbot_render_chat_shortcode');
+add_shortcode('dottorbot_diary', 'dottorbot_render_diary_shortcode');
+add_shortcode('dottorbot_privacy', 'dottorbot_render_privacy_shortcode');
 add_shortcode('dottorbot_progress', 'dottorbot_render_progress_shortcode');
 add_action('wp_footer', 'dottorbot_render_badge_notification');
 

--- a/wp-content/themes/dottorbot-theme/functions.php
+++ b/wp-content/themes/dottorbot-theme/functions.php
@@ -51,26 +51,6 @@ function dottorbot_enqueue_assets() {
 }
 add_action('wp_enqueue_scripts', 'dottorbot_enqueue_assets');
 
-function dottorbot_render_chat_shortcode() {
-    wp_enqueue_script('dottorbot-chat');
-    return '<div id="dottorbot-chat"></div>';
-}
-add_shortcode('dottorbot', 'dottorbot_render_chat_shortcode');
-
-function dottorbot_render_diary_shortcode() {
-    wp_enqueue_script('dottorbot-diary');
-    wp_enqueue_script('chartjs');
-    wp_enqueue_script('jspdf');
-    return '<div id="dottorbot-diary"></div>';
-}
-add_shortcode('dottorbot_diary', 'dottorbot_render_diary_shortcode');
-
-function dottorbot_render_privacy_shortcode() {
-    wp_enqueue_script('dottorbot-privacy');
-    return '<button id="dottorbot-privacy-open">' . esc_html__('Privacy', 'dottorbot') . '</button>';
-}
-add_shortcode('dottorbot_privacy', 'dottorbot_render_privacy_shortcode');
-
 function dottorbot_register_block() {
     wp_register_script(
         'dottorbot-block-editor',


### PR DESCRIPTION
## Summary
- Migrate chat, diary, and privacy shortcodes into the DottorBot plugin and register them there
- Remove shortcode implementations from the theme to keep it focused on asset enqueues

## Testing
- `php -l wp-content/plugins/dottorbot/dottorbot.php`
- `php -l wp-content/themes/dottorbot-theme/functions.php`


------
https://chatgpt.com/codex/tasks/task_e_689bbfb0100c8333b6d371de38f3353c