### PR TITLE
Call wp_body_open in theme templates

### DIFF
--- a/wp-content/themes/dottorbot-theme/front-page.php
+++ b/wp-content/themes/dottorbot-theme/front-page.php
@@ -7,6 +7,7 @@
     <?php wp_head(); ?>
 </head>
 <body <?php body_class(); ?>>
+    <?php wp_body_open(); ?>
     <main class="prose mx-auto p-4">
         <?php
         echo do_shortcode('[dottorbot]');

--- a/wp-content/themes/dottorbot-theme/index.php
+++ b/wp-content/themes/dottorbot-theme/index.php
@@ -7,6 +7,7 @@
     <?php wp_head(); ?>
 </head>
 <body <?php body_class(); ?>>
+    <?php wp_body_open(); ?>
     <main class="prose mx-auto p-4">
     <?php
     if (have_posts()) {


### PR DESCRIPTION
## Summary
- Invoke `wp_body_open()` immediately after `<body>` in `front-page.php` and `index.php` to comply with WordPress best practices.

## Testing
- `npm install`
- `npm run build` *(fails: Specified input file src/input.css does not exist)*
- `npm test`
- `(cd wp-content/themes/dottorbot-theme && composer install --no-dev)`
- `(cd wp-content/themes/dottorbot-theme && npm install)`
- `(cd wp-content/themes/dottorbot-theme && npm run build)`
- `(cd wp-content/themes/dottorbot-theme && npm test)`

------
https://chatgpt.com/codex/tasks/task_e_689bd4ee120083338f765e5b068a4019