### PR TITLE
Add noscript fallback and chat.js existence check

### DIFF
--- a/wp-content/plugins/dottorbot/dottorbot.php
+++ b/wp-content/plugins/dottorbot/dottorbot.php
@@ -818,8 +818,12 @@ function dottorbot_render_badge_notification(): void {
 }
 
 function dottorbot_render_chat_shortcode() {
+    $chat_path = get_template_directory() . '/dist/chat.js';
+    if (!file_exists($chat_path)) {
+        return '<div class="dottorbot-missing-js">' . esc_html__('File dist/chat.js mancante. Esegui `npm run build`.', 'dottorbot') . '</div>';
+    }
     wp_enqueue_script('dottorbot-chat');
-    return '<div id="dottorbot-chat"></div>';
+    return '<div id="dottorbot-chat"><noscript>Attiva JavaScript per usare DottorBot.</noscript></div>';
 }
 
 function dottorbot_render_diary_shortcode() {


### PR DESCRIPTION
## Summary
- Display noscript message inside chat shortcode
- Warn when dist/chat.js is missing to prompt build

## Testing
- `npm install`
- `npm run build` *(fails: Specified input file src/input.css does not exist)*
- `(cd wp-content/themes/dottorbot-theme && npm install && npm run build && composer install --no-dev && npm test)`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689c3a0788508333b8c13a57c5e24f58